### PR TITLE
nix: don't use qchem.python3

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,7 +1,9 @@
 final: prev: {
-  python3 = prev.qchem.python3.override (old: {
+  python3 = prev.python3.override (old: {
     packageOverrides = prev.lib.composeExtensions (old.packageOverrides or (_: _: { })) (pfinal: pprev: {
-      thermoanalysis = pfinal.callPackage ./thermoanalysis.nix { };
+      thermoanalysis = pfinal.callPackage ./thermoanalysis.nix {
+        inherit (final.qchem.python3.pkgs) cclib;
+      };
     });
   });
 }


### PR DESCRIPTION
Addendum, sorry. Should've used `prev.python3` instead of `prev.qchem.python3` ...